### PR TITLE
A1SDS-2770 Remove Default Policy

### DIFF
--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/retrieverl/service/PolicyProvider.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/retrieverl/service/PolicyProvider.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.sde.retrieverl.service;
 import java.util.List;
 
 import org.eclipse.tractusx.sde.common.entities.PolicyModel;
+import org.eclipse.tractusx.sde.common.exception.ValidationException;
 import org.eclipse.tractusx.sde.core.policy.service.PolicyService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -96,10 +97,11 @@ public class PolicyProvider {
 		return policyByName;
 	}
 
+	@SneakyThrows
 	public PolicyModel getMatchingPolicyBasedOnFileName(String fileName) {
 		List<PolicyModel> matchingList = policyService.findMatchingPolicyBasedOnFileName(fileName);
 		if (matchingList.isEmpty())
-			return getDefaultPolicy();
+			throw new ValidationException("No matching policy found");
 		else {
 			log.info("Applying policy " + matchingList.get(0).getPolicyName());
 			return matchingList.get(0);

--- a/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/retrieverl/service/ProcessRemoteCsv.java
+++ b/modules/sde-core/src/main/java/org/eclipse/tractusx/sde/retrieverl/service/ProcessRemoteCsv.java
@@ -213,7 +213,8 @@ public class ProcessRemoteCsv {
 					inProgressIdList, schedulerId), Instant.now().plus(Duration.ofSeconds(5)));
 		} else {
 			// In case of error this will send the notification. E.g. policy not present
-			sendEmailNotification(schedulerId);
+			// Send this email after 5 seconds to finish 'update trigger' from caller method
+			taskScheduler.schedule(() -> sendEmailNotification(schedulerId), Instant.now().plus(Duration.ofSeconds(5)));
 		}
 	}
 


### PR DESCRIPTION
If the policy mentioned in the filename is not present in the database then that file will not get processed.
Earlier we used to select default policy for such files. Now we removed that implementation in this PR.